### PR TITLE
Fix custom cursor resetting to top-left

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@
         // --- Global Event Listeners ---
         window.addEventListener('mousemove', (e) => { mouse.x = e.clientX; mouse.y = e.clientY; }, { passive: true });
         window.addEventListener('touchmove', (e) => { if (e.touches.length > 0) { mouse.x = e.touches[0].clientX; mouse.y = e.touches[0].clientY; } }, { passive: true });
-        window.addEventListener('mouseout', () => { mouse.x = null; mouse.y = null; });
+        window.addEventListener('mouseleave', () => { mouse.x = null; mouse.y = null; }); // reset only when leaving viewport
         window.addEventListener('touchend', () => { mouse.x = null; mouse.y = null; });
 
         // --- Debounced Resize Handler ---


### PR DESCRIPTION
## Summary
- ensure cursor tracking resets only when leaving the viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897707e1af4832f8c93deefe09ecc6a